### PR TITLE
添加多运行环境支持

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.profiles.active=prod
+spring.profiles.active=easyDeploy
 ####七牛的配置
 ####cn.celess.blog.service.serviceimpl.QiniuServiceImpl
 logging.level.cn.celess.blog=debug


### PR DESCRIPTION
- 文件存储
  - [ ] 添加本地服务器为默认存储位置
  - [ ] 阿里云/腾讯云/七牛云 oss 文件存储 作为备选 并提供设置来切换
- 数据库
  - [ ] 添加h2本地服务作为默认数据库
  - [ ] 提供配置接口来切换mysql和h2
- 缓存
  - [ ] 选用本地的缓存服务为默认的 
  - [ ] 提供配置接口来进行mysql和本地缓存的切换
